### PR TITLE
implement mgotest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+go_import_path: "github.com/juju/mgotest"
+go: 
+  - "1.9"
+  - "1.10"
+before_install:
+  - "go get github.com/rogpeppe/godeps"
+install:
+  - "go get -d github.com/juju/mgotest"
+  - "godeps -u $GOPATH/src/github.com/juju/mgotest/dependencies.tsv"
+script: go test ./...
+services:
+  - mongodb

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+All files in this repository are licensed as follows. If you contribute
+to this repository, it is assumed that you license your contribution
+under the same license unless you state otherwise.
+
+All files Copyright (C) 2018 Canonical Ltd. unless otherwise specified in the file.
+
+This software is licensed under the LGPLv3, included below.
+
+As a special exception to the GNU Lesser General Public License version 3
+("LGPL3"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code as set out in 4d or providing the installation
+information set out in section 4e, provided that you comply with the other
+provisions of LGPL3 and provided that you meet, for the Application the
+terms and conditions of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL3 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply.
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README
+++ b/README
@@ -1,0 +1,5 @@
+Simple support for Go testing with a live MongoDB database
+----
+
+This package makes it straightforward to write tests that connect
+to a fresh MongoDB database created for the tests.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,0 +1,6 @@
+github.com/frankban/quicktest	git	2c6a0d60c05cd2d970f356eee0623ddf1cd0d62d	2018-02-06T12:35:47Z
+github.com/google/go-cmp	git	8099a9787ce5dc5984ed879a3bda47dc730a8e97	2017-08-03T17:35:09Z
+github.com/kr/pretty	git	cfb55aafdaf3ec08f0db22699ab822c50091b1c4	2016-08-23T17:07:15Z
+github.com/kr/text	git	7cafcd837844e784b526369c9bce262804aebc60	2016-05-04T23:40:17Z
+gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
+gopkg.in/mgo.v2	git	3f83fa5005286a7fe593b055f0d7771a7dce4655	2016-08-18T02:01:20Z

--- a/mgotest.go
+++ b/mgotest.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package mgotest
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2"
+)
+
+var ErrDisabled = errgo.New("MongoDB testing is disabled")
+
+type Database struct {
+	*mgo.Database
+}
+
+// New connects to a MongoDB instance and returns a database
+// instance that uses it. The database name is randomly chosen; all
+// collections in the database will be removed when Close is called.
+//
+// The environment variable MGOCONNECTIONSTRING will
+// be consulted to determine the connection string to use
+// (see https://docs.mongodb.com/manual/reference/connection-string/
+// or https://godoc.org/gopkg.in/mgo.v2#Dial for details of the format).
+//
+// If MGOCONNECTIONSTRING is empty, "localhost" will be used.
+//
+// If the environment variable MGOTESTDISABLE is non-empty,
+// ErrDisabled will be returned.
+func New() (*Database, error) {
+	if os.Getenv("MGOTESTDISABLE") != "" {
+		return nil, ErrDisabled
+	}
+	connStr := os.Getenv("MGOCONNECTIONSTRING")
+	if connStr == "" {
+		connStr = "localhost"
+	}
+	session, err := mgo.Dial(connStr)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot dial MongoDB")
+	}
+	return &Database{
+		Database: session.DB(randomDatabaseName()),
+	}, nil
+}
+
+// Close drops the database and closes its associated session.
+func (db *Database) Close() error {
+	// TODO it would be nice if this could check that there
+	// were no currently open connections to the underlying
+	// session.
+	err := db.DropDatabase()
+	if err != nil {
+		return errgo.Notef(err, "cannot drop test database")
+	}
+	return nil
+}
+
+func randomDatabaseName() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Errorf("cannot read random bytes: %v", err))
+	}
+	return fmt.Sprintf("go_test_%x", buf)
+}

--- a/mgotest_test.go
+++ b/mgotest_test.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package mgotest_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/mgotest"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type testDoc struct {
+	ID string `bson:"_id"`
+	X  int
+}
+
+func TestNew(t *testing.T) {
+	c := qt.New(t)
+	db, err := mgotest.New()
+	c.Assert(err, qt.Equals, nil)
+
+	coll := db.C("collection")
+	// Check that we can actually use it.
+	err = coll.Insert(testDoc{ID: "foo", X: 99})
+	c.Assert(err, qt.Equals, nil)
+
+	var doc testDoc
+	err = coll.Find(bson.M{"_id": "foo"}).One(&doc)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(doc, qt.Equals, testDoc{"foo", 99})
+
+	// Create another one and check that it doesn't interfere.
+	db1, err := mgotest.New()
+	c.Assert(err, qt.Equals, nil)
+
+	coll1 := db1.C("collection")
+	err = coll1.Find(bson.M{"_id": "foo"}).One(&doc)
+	c.Assert(err, qt.Equals, mgo.ErrNotFound)
+
+	err = db1.Close()
+	c.Assert(err, qt.Equals, nil)
+
+	err = db.Close()
+	c.Assert(err, qt.Equals, nil)
+
+	// Connect again and check that the database has been deleted.
+	db2, err := mgotest.New()
+	c.Assert(err, qt.Equals, nil)
+	defer db2.Close()
+
+	// Create a *mgo.Database instance pointing at the original
+	// database name.
+	db3 := db2.Session.DB(db.Name)
+	coll3 := db3.C("collection")
+	err = coll3.Find(bson.M{"_id": "foo"}).One(&doc)
+	c.Assert(err, qt.Equals, mgo.ErrNotFound)
+}


### PR DESCRIPTION
The reason for this repo is so that we can connect to a live MongoDB
instance in tests rather than creating one for each package's tests
as github.com/juju/testing does. This should be faster and less error
prone, and it uses much less code.