### PR TITLE
use shared session

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,13 @@
+package mgotest
+
+func ResetGlobalState() {
+	sessionMu.Lock()
+	defer sessionMu.Unlock()
+	if session != nil {
+		session.Close()
+		session = nil
+	}
+	dialError = nil
+}
+
+var DialTimeout = &dialTimeout


### PR DESCRIPTION
To avoid the overhead of dialing MongoDB for every test,
we use a shared session that is returned each time.

The new NewExclusive function can be used to obtain a
separate session for tests that want to muck around with
per-session state.

We also fix a previous bug - we weren't closing the session
on Database.Close.